### PR TITLE
Fix handleAction() signature for PHP 8.5 compatibility

### DIFF
--- a/src/TwigController.php
+++ b/src/TwigController.php
@@ -2,8 +2,6 @@
 
 namespace Azt3k\SS\Twig;
 
-use SilverStripe\Control\HTTPRequest;
-
 trait TwigController {
 
     use TwigRenderer;
@@ -22,7 +20,7 @@ trait TwigController {
         return $this->hasMethod($name) ? false : true;
     }
 
-    public function handleAction(HTTPRequest $request, string $action): mixed
+    protected function handleAction($request, $action)
     {
         // urlParams, requestParams, and action are set for backward compatability
         foreach ($request->latestParams() as $k => $v) {


### PR DESCRIPTION
## Summary
- Match `handleAction()` signature to parent `Controller::handleAction($request, $action)`
- Remove typed parameters (`HTTPRequest $request, string $action`) and return type (`: mixed`)
- Change visibility from `public` to `protected` to match parent
- Remove unused `use SilverStripe\Control\HTTPRequest` import

## Problem
PHP 8.5 enforces stricter method signature compatibility. The trait's typed override causes a fatal error:
```
Fatal error: Declaration of PageController::handleAction(SilverStripe\Control\HTTPRequest $request, string $action): mixed
must be compatible with SilverStripe\Control\Controller::handleAction($request, $action)
```

## Test plan
- [x] Verified parent signature in `silverstripe/framework` 6.x: `protected function handleAction($request, $action)`
- [ ] CI passes on PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)